### PR TITLE
azsqs: add Queue.Len to get estimated number of messages in the queue

### DIFF
--- a/azsqs/queue.go
+++ b/azsqs/queue.go
@@ -317,6 +317,10 @@ func (q *Queue) CloseTimeout(timeout time.Duration) error {
 	return firstErr
 }
 
+func (q *Queue) Len(msg *msgqueue.Message) uint32 {
+	return q.Processor().Stats().InFlight
+}
+
 func (q *Queue) addBatcherAdd(msg *msgqueue.Message) error {
 	return q.addBatcher.Add(msg)
 }


### PR DESCRIPTION
Fixes #24.